### PR TITLE
SupportRightActionBarActivity updated, build.gradle updated, RightSwipeRefres…

### DIFF
--- a/Rightutils/app/build.gradle
+++ b/Rightutils/app/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-	compileSdkVersion 21
-	buildToolsVersion "21.1.2"
+	compileSdkVersion 22
+	buildToolsVersion "23.0.2"
 
 	defaultConfig {
 		minSdkVersion 8

--- a/Rightutils/app/src/main/java/com/rightutils/rightutils/activities/SupportRightActionBarActivity.java
+++ b/Rightutils/app/src/main/java/com/rightutils/rightutils/activities/SupportRightActionBarActivity.java
@@ -2,15 +2,16 @@ package com.rightutils.rightutils.activities;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 
 /**
  * Created by Anton Maniskevich on 12/5/14.
  */
-public class SupportRightActionBarActivity extends ActionBarActivity {
+public class SupportRightActionBarActivity extends AppCompatActivity {
 
 	private int fragmentContainer;
 	private Fragment initFragment;
@@ -52,6 +53,7 @@ public class SupportRightActionBarActivity extends ActionBarActivity {
 		}
 	}
 
+	@Nullable
 	public Fragment getLastFragment() {
 		if (getSupportFragmentManager().getBackStackEntryCount() == 0) {
 			return null;

--- a/Rightutils/app/src/main/java/com/rightutils/rightutils/widgets/RightSwipeRefreshLayout.java
+++ b/Rightutils/app/src/main/java/com/rightutils/rightutils/widgets/RightSwipeRefreshLayout.java
@@ -1,6 +1,5 @@
 package com.rightutils.rightutils.widgets;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -19,18 +18,17 @@ import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.Transformation;
 import android.widget.AbsListView;
-import android.widget.FrameLayout;
 
 /**
  * Created by Anton Maniskevich on 5/13/15.
  */
-public class RightSwipeRefreshLayour extends ViewGroup {
+public class RightSwipeRefreshLayout extends ViewGroup {
 	// Maps to ProgressBar.Large style
 	public static final int LARGE = MaterialProgressDrawable.LARGE;
 	// Maps to ProgressBar default style
 	public static final int DEFAULT = MaterialProgressDrawable.DEFAULT;
 
-	private static final String TAG = RightSwipeRefreshLayour.class.getSimpleName();
+	private static final String TAG = RightSwipeRefreshLayout.class.getSimpleName();
 
 	private static final int MAX_ALPHA = 255;
 	private static final int STARTING_PROGRESS_ALPHA = (int) (.3f * MAX_ALPHA);
@@ -243,11 +241,11 @@ public class RightSwipeRefreshLayour extends ViewGroup {
 		bottomCircleView.setImageDrawable(bottomProgress);
 	}
 
-	public RightSwipeRefreshLayour(Context context) {
+	public RightSwipeRefreshLayout(Context context) {
 		this(context, null);
 	}
 
-	public RightSwipeRefreshLayour(Context context, AttributeSet attrs) {
+	public RightSwipeRefreshLayout(Context context, AttributeSet attrs) {
 		super(context, attrs);
 		if (isInEditMode()) {
 			return;
@@ -322,7 +320,7 @@ public class RightSwipeRefreshLayour extends ViewGroup {
 		return android.os.Build.VERSION.SDK_INT < 11;
 	}
 
-	public void setRefreshing(boolean refreshing, @RightSwipeRefreshLayour.RefreshType int refreshType) {
+	public void setRefreshing(boolean refreshing, @RightSwipeRefreshLayout.RefreshType int refreshType) {
 		if (refreshType == TOP_REFRESH) {
 			if (refreshing && mRefreshing != refreshing) {
 				// scale and show

--- a/Rightutils/example/build.gradle
+++ b/Rightutils/example/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 21
-	buildToolsVersion "21.1.2"
+	compileSdkVersion 22
+	buildToolsVersion "23.0.2"
 
 	defaultConfig {
 		applicationId "com.rightutils.example"

--- a/Rightutils/example/src/main/java/com/rightutils/example/activities/RightSwipeRefreshActivity.java
+++ b/Rightutils/example/src/main/java/com/rightutils/example/activities/RightSwipeRefreshActivity.java
@@ -2,7 +2,6 @@ package com.rightutils.example.activities;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.ArrayAdapter;
@@ -10,15 +9,15 @@ import android.widget.ListView;
 
 import com.rightutils.example.R;
 import com.rightutils.rightutils.collections.RightList;
-import com.rightutils.rightutils.widgets.RightSwipeRefreshLayour;
+import com.rightutils.rightutils.widgets.RightSwipeRefreshLayout;
 
 /**
  * Created by Anton Maniskevich on 5/13/15.
  */
-public class RightSwipeRefreshActivity extends AppCompatActivity implements RightSwipeRefreshLayour.OnRefreshListener {
+public class RightSwipeRefreshActivity extends AppCompatActivity implements RightSwipeRefreshLayout.OnRefreshListener {
 
 	private static final String TAG = RightSwipeRefreshActivity.class.getSimpleName();
-	private RightSwipeRefreshLayour rightSwipeRefreshLayour;
+	private RightSwipeRefreshLayout rightSwipeRefreshLayout;
 	private ArrayAdapter adapter;
 
 	@Override
@@ -28,14 +27,14 @@ public class RightSwipeRefreshActivity extends AppCompatActivity implements Righ
 		RightList<String> values = RightList.asRightList("100", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114");
 		adapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, android.R.id.text1, values);
 		((ListView)findViewById(R.id.list_view)).setAdapter(adapter);
-		rightSwipeRefreshLayour = (RightSwipeRefreshLayour) findViewById(R.id.refresh);
-		rightSwipeRefreshLayour.setOnRefreshListener(this);
+		rightSwipeRefreshLayout = (RightSwipeRefreshLayout) findViewById(R.id.refresh);
+		rightSwipeRefreshLayout.setOnRefreshListener(this);
 	}
 
 
 	@Override
-	public void onRefresh(final @RightSwipeRefreshLayour.RefreshType int refreshType) {
-		rightSwipeRefreshLayour.setRefreshing(true, refreshType);
+	public void onRefresh(final @RightSwipeRefreshLayout.RefreshType int refreshType) {
+		rightSwipeRefreshLayout.setRefreshing(true, refreshType);
 		new AsyncTask<Void, Void, Void>() {
 			@Override
 			protected Void doInBackground(Void... params) {
@@ -50,14 +49,14 @@ public class RightSwipeRefreshActivity extends AppCompatActivity implements Righ
 			@Override
 			protected void onPostExecute(Void aVoid) {
 				switch (refreshType) {
-					case RightSwipeRefreshLayour.TOP_REFRESH:
+					case RightSwipeRefreshLayout.TOP_REFRESH:
 						int firstValue = Integer.valueOf((String) adapter.getItem(0));
 						if (firstValue > 90) {
 							adapter.insert(String.valueOf(--firstValue), 0);
 							adapter.insert(String.valueOf(--firstValue), 0);
 						}
 						break;
-					case RightSwipeRefreshLayour.BOTTOM_REFRESH:
+					case RightSwipeRefreshLayout.BOTTOM_REFRESH:
 						int lastValue = Integer.valueOf((String) adapter.getItem(adapter.getCount()-1));
 						Log.i(TAG, "lastValue="+lastValue);
 						if (lastValue < 124) {
@@ -67,7 +66,7 @@ public class RightSwipeRefreshActivity extends AppCompatActivity implements Righ
 						break;
 				}
 				adapter.notifyDataSetChanged();
-				rightSwipeRefreshLayour.setRefreshing(false, refreshType);
+				rightSwipeRefreshLayout.setRefreshing(false, refreshType);
 			}
 		}.execute();
 	}

--- a/Rightutils/example/src/main/java/com/rightutils/example/activities/RightSwipeRefreshRecycleViewActivity.java
+++ b/Rightutils/example/src/main/java/com/rightutils/example/activities/RightSwipeRefreshRecycleViewActivity.java
@@ -6,26 +6,22 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
 import android.widget.TextView;
 
 import com.rightutils.example.R;
-import com.rightutils.example.decorator.DividerItemDecoration;
 import com.rightutils.rightutils.collections.RightList;
-import com.rightutils.rightutils.widgets.RightSwipeRefreshLayour;
+import com.rightutils.rightutils.widgets.RightSwipeRefreshLayout;
 
 /**
  * Created by Anton Maniskevich on 5/13/15.
  */
-public class RightSwipeRefreshRecycleViewActivity extends AppCompatActivity implements RightSwipeRefreshLayour.OnRefreshListener {
+public class RightSwipeRefreshRecycleViewActivity extends AppCompatActivity implements RightSwipeRefreshLayout.OnRefreshListener {
 
 	private static final String TAG = RightSwipeRefreshRecycleViewActivity.class.getSimpleName();
-	private RightSwipeRefreshLayour rightSwipeRefreshLayour;
+	private RightSwipeRefreshLayout rightSwipeRefreshLayout;
 	private SimpleAdapter adapter;
 	private LinearLayoutManager mLayoutManager;
 	private RecyclerView mRecyclerView;
@@ -42,14 +38,14 @@ public class RightSwipeRefreshRecycleViewActivity extends AppCompatActivity impl
 		RightList<String> values = RightList.asRightList("100", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114");
 		adapter = new SimpleAdapter(values);
 		mRecyclerView.setAdapter(adapter);
-		rightSwipeRefreshLayour = (RightSwipeRefreshLayour) findViewById(R.id.refresh);
-		rightSwipeRefreshLayour.setOnRefreshListener(this);
+		rightSwipeRefreshLayout = (RightSwipeRefreshLayout) findViewById(R.id.refresh);
+		rightSwipeRefreshLayout.setOnRefreshListener(this);
 	}
 
 
 	@Override
-	public void onRefresh(final @RightSwipeRefreshLayour.RefreshType int refreshType) {
-		rightSwipeRefreshLayour.setRefreshing(true, refreshType);
+	public void onRefresh(final @RightSwipeRefreshLayout.RefreshType int refreshType) {
+		rightSwipeRefreshLayout.setRefreshing(true, refreshType);
 		new AsyncTask<Void, Void, Void>() {
 			@Override
 			protected Void doInBackground(Void... params) {
@@ -64,14 +60,14 @@ public class RightSwipeRefreshRecycleViewActivity extends AppCompatActivity impl
 			@Override
 			protected void onPostExecute(Void aVoid) {
 				switch (refreshType) {
-					case RightSwipeRefreshLayour.TOP_REFRESH:
+					case RightSwipeRefreshLayout.TOP_REFRESH:
 						int firstValue = Integer.valueOf(adapter.getItem(0));
 						if (firstValue > 90) {
 							adapter.addTop(RightList.asRightList(String.valueOf(firstValue-2), String.valueOf(firstValue-1)));
 						}
 						mLayoutManager.scrollToPositionWithOffset(0, 0);
 						break;
-					case RightSwipeRefreshLayour.BOTTOM_REFRESH:
+					case RightSwipeRefreshLayout.BOTTOM_REFRESH:
 						int lastValue = Integer.valueOf(adapter.getItem(adapter.getItemCount()-1));
 						if (lastValue < 124) {
 							adapter.addToBottom(RightList.asRightList(String.valueOf(lastValue + 1), String.valueOf(lastValue + 2)));
@@ -79,7 +75,7 @@ public class RightSwipeRefreshRecycleViewActivity extends AppCompatActivity impl
 						mLayoutManager.scrollToPositionWithOffset(mLayoutManager.findFirstCompletelyVisibleItemPosition()+1,0);
 						break;
 				}
-				rightSwipeRefreshLayour.setRefreshing(false, refreshType);
+				rightSwipeRefreshLayout.setRefreshing(false, refreshType);
 			}
 		}.execute();
 	}

--- a/Rightutils/example/src/main/java/com/rightutils/example/activities/RightSwipeRefreshViewPagerActivity.java
+++ b/Rightutils/example/src/main/java/com/rightutils/example/activities/RightSwipeRefreshViewPagerActivity.java
@@ -1,21 +1,16 @@
 package com.rightutils.example.activities;
 
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.View;
-import android.widget.ArrayAdapter;
-import android.widget.ListView;
 
 import com.rightutils.example.R;
 import com.rightutils.example.fragments.RightSwipeRefreshFragment;
 import com.rightutils.rightutils.collections.RightList;
-import com.rightutils.rightutils.widgets.RightSwipeRefreshLayour;
 
 /**
  * Created by Anton Maniskevich on 5/13/15.

--- a/Rightutils/example/src/main/java/com/rightutils/example/fragments/RightSwipeRefreshFragment.java
+++ b/Rightutils/example/src/main/java/com/rightutils/example/fragments/RightSwipeRefreshFragment.java
@@ -13,15 +13,15 @@ import android.widget.ListView;
 
 import com.rightutils.example.R;
 import com.rightutils.rightutils.collections.RightList;
-import com.rightutils.rightutils.widgets.RightSwipeRefreshLayour;
+import com.rightutils.rightutils.widgets.RightSwipeRefreshLayout;
 
 /**
  * Created by Anton Maniskevich on 5/20/15.
  */
-public class RightSwipeRefreshFragment extends Fragment implements RightSwipeRefreshLayour.OnRefreshListener {
+public class RightSwipeRefreshFragment extends Fragment implements RightSwipeRefreshLayout.OnRefreshListener {
 
 	private static final String TAG = RightSwipeRefreshFragment.class.getSimpleName();
-	private RightSwipeRefreshLayour rightSwipeRefreshLayour;
+	private RightSwipeRefreshLayout rightSwipeRefreshLayout;
 	private ArrayAdapter adapter;
 
 	public static RightSwipeRefreshFragment newInstance() {
@@ -40,13 +40,13 @@ public class RightSwipeRefreshFragment extends Fragment implements RightSwipeRef
 		RightList<String> values = RightList.asRightList("100", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111", "112", "113", "114");
 		adapter = new ArrayAdapter<String>(getActivity(), android.R.layout.simple_list_item_1, android.R.id.text1, values);
 		((ListView)view.findViewById(R.id.list_view)).setAdapter(adapter);
-		rightSwipeRefreshLayour = (RightSwipeRefreshLayour) view.findViewById(R.id.refresh);
-		rightSwipeRefreshLayour.setOnRefreshListener(this);
+		rightSwipeRefreshLayout = (RightSwipeRefreshLayout) view.findViewById(R.id.refresh);
+		rightSwipeRefreshLayout.setOnRefreshListener(this);
 	}
 
 	@Override
-	public void onRefresh(final @RightSwipeRefreshLayour.RefreshType int refreshType) {
-		rightSwipeRefreshLayour.setRefreshing(true, refreshType);
+	public void onRefresh(final @RightSwipeRefreshLayout.RefreshType int refreshType) {
+		rightSwipeRefreshLayout.setRefreshing(true, refreshType);
 		new AsyncTask<Void, Void, Void>() {
 			@Override
 			protected Void doInBackground(Void... params) {
@@ -61,14 +61,14 @@ public class RightSwipeRefreshFragment extends Fragment implements RightSwipeRef
 			@Override
 			protected void onPostExecute(Void aVoid) {
 				switch (refreshType) {
-					case RightSwipeRefreshLayour.TOP_REFRESH:
+					case RightSwipeRefreshLayout.TOP_REFRESH:
 						int firstValue = Integer.valueOf((String) adapter.getItem(0));
 						if (firstValue > 90) {
 							adapter.insert(String.valueOf(--firstValue), 0);
 							adapter.insert(String.valueOf(--firstValue), 0);
 						}
 						break;
-					case RightSwipeRefreshLayour.BOTTOM_REFRESH:
+					case RightSwipeRefreshLayout.BOTTOM_REFRESH:
 						int lastValue = Integer.valueOf((String) adapter.getItem(adapter.getCount()-1));
 						Log.i(TAG, "lastValue=" + lastValue);
 						if (lastValue < 124) {
@@ -78,7 +78,7 @@ public class RightSwipeRefreshFragment extends Fragment implements RightSwipeRef
 						break;
 				}
 				adapter.notifyDataSetChanged();
-				rightSwipeRefreshLayour.setRefreshing(false, refreshType);
+				rightSwipeRefreshLayout.setRefreshing(false, refreshType);
 			}
 		}.execute();
 	}

--- a/Rightutils/example/src/main/res/layout/activity_right_swipe_refresh.xml
+++ b/Rightutils/example/src/main/res/layout/activity_right_swipe_refresh.xml
@@ -4,7 +4,7 @@
 			  android:layout_height="match_parent"
 			  android:orientation="vertical">
 
-	<com.rightutils.rightutils.widgets.RightSwipeRefreshLayour
+	<com.rightutils.rightutils.widgets.RightSwipeRefreshLayout
 		android:id="@+id/refresh"
 		android:layout_width="match_parent"
 		android:layout_weight="1"
@@ -16,6 +16,6 @@
 			android:choiceMode="singleChoice"
 			android:divider="@android:color/transparent"
 			android:dividerHeight="1dp"/>
-	</com.rightutils.rightutils.widgets.RightSwipeRefreshLayour>
+	</com.rightutils.rightutils.widgets.RightSwipeRefreshLayout>
 
 </LinearLayout>

--- a/Rightutils/example/src/main/res/layout/activity_right_swipe_refresh_recyclerview.xml
+++ b/Rightutils/example/src/main/res/layout/activity_right_swipe_refresh_recyclerview.xml
@@ -4,7 +4,7 @@
 			  android:layout_height="match_parent"
 			  android:orientation="vertical">
 
-	<com.rightutils.rightutils.widgets.RightSwipeRefreshLayour
+	<com.rightutils.rightutils.widgets.RightSwipeRefreshLayout
 		android:id="@+id/refresh"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent">
@@ -14,6 +14,6 @@
 			android:layout_height="match_parent"
 			android:divider="@android:color/transparent"
 			android:dividerHeight="1dp"/>
-	</com.rightutils.rightutils.widgets.RightSwipeRefreshLayour>
+	</com.rightutils.rightutils.widgets.RightSwipeRefreshLayout>
 
 </LinearLayout>

--- a/Rightutils/example/src/main/res/layout/fragment_right_swipe_refresh.xml
+++ b/Rightutils/example/src/main/res/layout/fragment_right_swipe_refresh.xml
@@ -4,7 +4,7 @@
 			  android:layout_width="match_parent"
 			  android:layout_height="match_parent">
 
-	<com.rightutils.rightutils.widgets.RightSwipeRefreshLayour
+	<com.rightutils.rightutils.widgets.RightSwipeRefreshLayout
 		android:id="@+id/refresh"
 		android:layout_width="match_parent"
 		android:layout_weight="1"
@@ -16,6 +16,6 @@
 			android:choiceMode="singleChoice"
 			android:divider="@android:color/transparent"
 			android:dividerHeight="1dp"/>
-	</com.rightutils.rightutils.widgets.RightSwipeRefreshLayour>
+	</com.rightutils.rightutils.widgets.RightSwipeRefreshLayout>
 
 </LinearLayout>


### PR DESCRIPTION
SupportRightActionBarActivity updated, build.gradle updated, RightSwipeRefreshLayout name fixed.

- SupportRightActionBarActivity now extends AppCompatActivity instead deprecated ActionBarActivity. Added @Nullable annotation in getLastFragment() method.

- build.gradle: updated compileSdkVersion to 22 and buildToolsVersion to 23.0.2.

- Renamed RightSwipeRefreshLayour to RightSwipeRefreshLayout
